### PR TITLE
Update order.ex

### DIFF
--- a/lib/witchcraft/orderable/order.ex
+++ b/lib/witchcraft/orderable/order.ex
@@ -1,7 +1,7 @@
 import TypeClass
 
 defmodule Witchcraft.Orderable.Order do
-  @type t :: Equal.t | Greater.t | Less.t
+  @type t :: Equal.t | Greater.t | Lesser.t
 
   defmodule Greater do
     @type t :: %Greater{}


### PR DESCRIPTION
Typo fix.

Also, this file may be over-engineered, perhaps the simple atoms of `:gt`, `:lt`, and `:eq` may be better as those are fairly standard names (although `-1`, `0`, and `1` are the most common among the erlang/elixir world as they compare ordered properly as well where the atoms do not compare ordered properly, neither do the structs in this file) and much faster on testing and comparisons (although not-standard, more descriptive names like `:greater`, `:lesser`, and `:equal` would be nice).