### PR TITLE
Fix do notation

### DIFF
--- a/lib/witchcraft/chain.ex
+++ b/lib/witchcraft/chain.ex
@@ -418,19 +418,13 @@ defclass Witchcraft.Chain do
     |> Enum.reverse()
     |> Witchcraft.Foldable.left_fold(fn
       (continue, {:let, _, [{:=, _, [assign, value]}]}) ->
-        quote do
-          unquote(value) |> fn unquote(assign) -> unquote(continue) end.()
-        end
+        quote do: unquote(value) |> fn unquote(assign) -> unquote(continue) end.()
 
       (continue, {:<-, _, [assign, value]}) ->
-        quote do
-          unquote(value) >>> (fn unquote(assign) -> unquote(continue) end)
-        end
+        quote do: unquote(value) >>> (fn unquote(assign) -> unquote(continue) end)
 
       (continue, value) ->
-        quote do
-          unquote(value) >>> fn _ -> unquote(continue) end
-        end
+        quote do: unquote(value) >>> fn _ -> unquote(continue) end
     end)
   end
 

--- a/lib/witchcraft/chain.ex
+++ b/lib/witchcraft/chain.ex
@@ -390,6 +390,19 @@ defclass Witchcraft.Chain do
   but is often much cleaner to read in do-notation, as it cleans up all of the
   nested functions (especially when the chain is very long).
 
+  You can also use values recursively:
+
+      chain do
+        a <- [1, 2, 3]
+        b <- [a, a * 10, a * 100]
+        [a + 1, b + 1]
+      end
+      [
+        2, 2, 2, 11, 2, 101,
+        3, 3, 3, 21, 3, 201,
+        4, 4, 4, 31, 4, 301
+      ]
+
   """
   defmacro chain(do: input) do
     Witchcraft.Chain.do_notation(input, &Witchcraft.Chain.chain/2)

--- a/lib/witchcraft/chain.ex
+++ b/lib/witchcraft/chain.ex
@@ -413,31 +413,21 @@ defclass Witchcraft.Chain do
   @doc false
   # credo:disable-for-lines:31 Credo.Check.Refactor.Nesting
   def do_notation(input, chainer) do
-    IO.puts ">>>>>>>>>>>>>>>>>"
-
     input
     |> normalize()
-    |> IO.inspect()
-    # |> Enum.reverse()
+    |> Enum.reverse()
     |> Witchcraft.Foldable.left_fold(fn
-      (drawing = {:<-, _, [assign = {left_sym, left_ctx, _}, value]}, continue) ->
-        IO.puts "DRAWING:"
-        IO.inspect drawing
-
-        IO.puts "ASSIGN:"
-        IO.inspect assign
-
-        IO.puts "VALUE:"
-        IO.inspect value
-
-        IO.puts "RIGHT:"
-        IO.inspect continue
-
+      (continue, {:let, _, [{:=, _, [assign, value]}]}) ->
         quote do
-          unquote(value) >>> fn unquote(assign) -> unquote(continue) end
+          unquote(value) |> fn unquote(assign) -> unquote(continue) end.()
         end
 
-      (value, continue) ->
+      (continue, {:<-, _, [assign, value]}) ->
+        quote do
+          unquote(value) >>> (fn unquote(assign) -> unquote(continue) end)
+        end
+
+      (continue, value) ->
         quote do
           unquote(value) >>> fn _ -> unquote(continue) end
         end

--- a/lib/witchcraft/monad.ex
+++ b/lib/witchcraft/monad.ex
@@ -196,6 +196,11 @@ defclass Witchcraft.Monad do
       [1]
 
       iex> monad [] do
+      ...>   return 1
+      ...> end
+      [1]
+
+      iex> monad [] do
       ...>  a <- [1,2,3]
       ...>  b <- [4,5,6]
       ...>  return(a * b)

--- a/lib/witchcraft/monad.ex
+++ b/lib/witchcraft/monad.ex
@@ -201,9 +201,9 @@ defclass Witchcraft.Monad do
       ...>  return(a * b)
       ...> end
       [
-        4, 8,  12,
-        5, 10, 15,
-        6, 12, 18
+        4,  5,  6,
+        8,  10, 12,
+        12, 15, 18
       ]
 
       iex> monad [] do
@@ -258,9 +258,9 @@ defclass Witchcraft.Monad do
       ...>  return(a * b)
       ...> end
       [
-      4, 8,  12,
-      5, 10, 15,
-      6, 12, 18
+        4,  5,  6,
+        8,  10, 12,
+        12, 15, 18
       ]
 
       iex> async [] do

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Witchcraft.Mixfile do
       name: "Witchcraft",
       description: "Common algebras (monoids, functors, monads, &c)",
 
-      version: "1.0.0-beta.4",
+      version: "1.0.0-rc.0",
       elixir:  "~> 1.5",
 
       package: [

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Witchcraft.Mixfile do
     [
       app:  :witchcraft,
       name: "Witchcraft",
-      description: "Common algebras (monoids, functors, monads, &c)",
+      description: "Monads and other dark magic (monoids, functors, traversables, &c)",
 
       version: "1.0.0-rc.0",
       elixir:  "~> 1.5",

--- a/test/do_notation_test.exs
+++ b/test/do_notation_test.exs
@@ -21,6 +21,17 @@ defmodule Witchcraft.DoNotationTest do
     assert done == [4, 5, 6, 4, 5, 6, 4, 5, 6]
   end
 
+  test "return from multiple draws" do
+    done =
+      chain do
+        a <- [1, 2, 3]
+        b <- [4, 5, 6]
+        [a * b]
+      end
+
+    assert done == [4, 5, 6, 8, 10, 12, 12, 15, 18]
+  end
+
   test "draw one line and immedietly use it" do
     done =
       chain do

--- a/test/do_notation_test.exs
+++ b/test/do_notation_test.exs
@@ -1,0 +1,44 @@
+defmodule WitchcraftTest do
+  use ExUnit.Case, async: true
+  use Witchcraft.Chain
+
+  test "single line" do
+    done =
+      chain do
+        [1, 2, 3]
+      end
+
+    assert done == [1, 2, 3]
+  end
+
+  test "multiple lines, default then" do
+    done =
+      chain do
+        [1, 2, 3]
+        [4, 5, 6]
+      end
+
+    assert done == [4, 5, 6, 4, 5, 6, 4, 5, 6]
+  end
+
+  test "draw one line and immedietly use it" do
+    done =
+      chain do
+        a <- [1, 2, 3]
+        [a, a * 10, a * 100]
+      end
+
+    assert done == [1, 10, 100, 2, 20, 200, 3, 30, 300]
+  end
+
+  # test "use recursively drawn elements" do
+  #   done =
+  #     chain do
+  #       a <- [1, 2, 3]
+  #       b <- [a * 10]
+  #       [a + b]
+  #     end
+
+  #   assert done == [11, 22, 33]
+  # end
+end

--- a/test/do_notation_test.exs
+++ b/test/do_notation_test.exs
@@ -90,4 +90,16 @@ defmodule Witchcraft.DoNotationTest do
 
     assert done == [1.0, 10.0, 100.0, 2.0, 20.0, 100.0, 3.0, 30.0, 100.0]
   end
+
+  test "destructiring let" do
+    done =
+      chain do
+        a <- [1, 2]
+        b <- [3, 4]
+        let [h | _] = [a * b]
+        [h, h, h]
+      end
+
+    assert done == [3, 3, 3, 4, 4, 4, 6, 6, 6, 8, 8, 8]
+  end
 end

--- a/test/do_notation_test.exs
+++ b/test/do_notation_test.exs
@@ -1,4 +1,4 @@
-defmodule WitchcraftTest do
+defmodule Witchcraft.DoNotationTest do
   use ExUnit.Case, async: true
   use Witchcraft.Chain
 
@@ -31,14 +31,63 @@ defmodule WitchcraftTest do
     assert done == [1, 10, 100, 2, 20, 200, 3, 30, 300]
   end
 
-  # test "use recursively drawn elements" do
-  #   done =
-  #     chain do
-  #       a <- [1, 2, 3]
-  #       b <- [a * 10]
-  #       [a + b]
-  #     end
+  test "draw one line and use it repeatedly" do
+    done =
+      chain do
+        a <- [1, 2, 3]
+        [a]
+        [a]
+    end
 
-  #   assert done == [11, 22, 33]
-  # end
+    assert done == [1, 2, 3]
+  end
+
+  test "use recursively drawn elements" do
+    done =
+      chain do
+        a <- [1, 2, 3]
+        b <- [a * 10]
+        [a + b]
+      end
+
+    assert done == [11, 22, 33]
+  end
+
+  test "multiple recursive uses" do
+    done =
+      chain do
+        a <- [1, 2, 3]
+        b <- [a * 10]
+        c <- [a + b]
+        [a, b, c]
+      end
+
+    assert done == [1, 10, 11, 2, 20, 22, 3, 30, 33]
+  end
+
+  test "top let bindings" do
+    done =
+      chain do
+        let values = [1, 2, 3]
+        a <- values
+        b <- [a * 10]
+        c <- [a + b]
+        [a, b, c]
+      end
+
+    assert done == [1, 10, 11, 2, 20, 22, 3, 30, 33]
+  end
+
+  test "intermediate let bindings" do
+    done =
+      chain do
+        a <- [1, 2, 3]
+        b <- [a * 10]
+        let foo = b / a
+        c <- [foo * foo]
+        [a, b, c]
+      end
+
+    assert done == [1.0, 10.0, 100.0, 2.0, 20.0, 100.0, 3.0, 30.0, 100.0]
+  end
 end

--- a/test/do_notation_test.exs
+++ b/test/do_notation_test.exs
@@ -102,7 +102,7 @@ defmodule Witchcraft.DoNotationTest do
     assert done == [1.0, 10.0, 100.0, 2.0, 20.0, 100.0, 3.0, 30.0, 100.0]
   end
 
-  test "destructiring let" do
+  test "destructuring let" do
     done =
       chain do
         a <- [1, 2]
@@ -112,5 +112,45 @@ defmodule Witchcraft.DoNotationTest do
       end
 
     assert done == [3, 3, 3, 4, 4, 4, 6, 6, 6, 8, 8, 8]
+  end
+
+  test "recursive lets" do
+    done =
+      chain do
+        a <- [1, 2]
+        b <- [3, 4]
+        let [h | _] = [a * b]
+        c <- [a, b, h]
+        let tens = c * 10
+        d <- [c - 1, c + 1]
+        [a, b, c, d]
+    end
+
+    assert done == [
+      1, 3, 1, 0,
+      1, 3, 1, 2,
+      1, 3, 3, 2,
+      1, 3, 3, 4,
+      1, 3, 3, 2,
+      1, 3, 3, 4,
+      1, 4, 1, 0,
+      1, 4, 1, 2,
+      1, 4, 4, 3,
+      1, 4, 4, 5,
+      1, 4, 4, 3,
+      1, 4, 4, 5,
+      2, 3, 2, 1,
+      2, 3, 2, 3,
+      2, 3, 3, 2,
+      2, 3, 3, 4,
+      2, 3, 6, 5,
+      2, 3, 6, 7,
+      2, 4, 2, 1,
+      2, 4, 2, 3,
+      2, 4, 4, 3,
+      2, 4, 4, 5,
+      2, 4, 8, 7,
+      2, 4, 8, 9
+    ]
   end
 end


### PR DESCRIPTION
Chain/monad do notation got mangled somewhere along the way. Works again, and added specific `do_notation_test.exs` specs.

Fixes #43 